### PR TITLE
Переиспользование тегов из конфига для очистки текста от ббкодов

### DIFF
--- a/system/config/bbcode.global.php
+++ b/system/config/bbcode.global.php
@@ -6,71 +6,85 @@ return [
         'b'       => [
             'from' => '#\[b](.+?)\[/b]#is',
             'to'   => '<span style="font-weight: bold">$1</span>',
+            'data' => '$1',
         ],
         // Курсив
         'i'       => [
             'from' => '#\[i](.+?)\[/i]#is',
             'to'   => '<span style="font-style:italic">$1</span>',
+            'data' => '$1',
         ],
         // Подчёркнутый
         'u'       => [
             'from' => '#\[u](.+?)\[/u]#is',
             'to'   => '<span style="text-decoration:underline">$1</span>',
+            'data' => '$1',
         ],
         // Зачёркнутый
         's'       => [
             'from' => '#\[s](.+?)\[/s]#is',
             'to'   => '<span style="text-decoration:line-through">$1</span>',
+            'data' => '$1',
         ],
         // Маленький шрифт
         'small'   => [
             'from' => '#\[small](.+?)\[/small]#is',
             'to'   => '<span style="font-size:x-small">$1</span>',
+            'data' => '$1',
         ],
         // Большой шрифт
         'big'     => [
             'from' => '#\[big](.+?)\[/big]#is',
             'to'   => '<span style="font-size:large">$1</span>',
+            'data' => '$1',
         ],
         // Красный
         'red'     => [
             'from' => '#\[red](.+?)\[/red]#is',
             'to'   => '<span style="color:red">$1</span>',
+            'data' => '$1',
         ],
         // Зеленый
         'green'   => [
             'from' => '#\[green](.+?)\[/green]#is',
             'to'   => '<span style="color:green">$1</span>',
+            'data' => '$1',
         ],
         // Синий
         'blue'    => [
             'from' => '#\[blue](.+?)\[/blue]#is',
             'to'   => '<span style="color:blue">$1</span>',
+            'data' => '$1',
         ],
         // Цвет шрифта
         'color'   => [
             'from' => '!\[color=(#[0-9a-f]{3}|#[0-9a-f]{6}|[a-z\-]+)](.+?)\[/color]!is',
             'to'   => '<span style="color:$1">$2</span>',
+            'data' => '$2',
         ],
         // Цвет фона
         'bg'      => [
             'from' => '!\[bg=(#[0-9a-f]{3}|#[0-9a-f]{6}|[a-z\-]+)](.+?)\[/bg]!is',
             'to'   => '<span style="background-color:$1">$2</span>',
+            'data' => '$2',
         ],
         // Цитата
         'quote'   => [
             'from' => '#\[(quote|c)](.+?)\[/(quote|c)]#is',
             'to'   => '<span class="quote" style="display:block">$2</span>',
+            'data' => '$2',
         ],
         // Список
         'list'    => [
             'from' => '#\[\*](.+?)\[/\*]#is',
             'to'   => '<span class="bblist">$1</span>',
+            'data' => '$1',
         ],
         // Спойлер
         'spoiler' => [
             'from' => '#\[spoiler=(.+?)](.+?)\[/spoiler]#is',
             'to'   => '<div><div class="spoilerhead" style="cursor:pointer;" onclick="var _n=this.parentNode.getElementsByTagName(\'div\')[1];if(_n.style.display==\'none\'){_n.style.display=\'\';}else{_n.style.display=\'none\';}">$1 (+/-)</div><div class="spoilerbody" style="display:none">$2</div></div>',
+            'data' => '$1',
         ],
     ],
 

--- a/system/johncms/Bbcode.php
+++ b/system/johncms/Bbcode.php
@@ -67,40 +67,19 @@ class Bbcode implements Api\BbcodeInterface
 
     public function notags($var = '')
     {
-        $var = preg_replace('#\[color=(.+?)\](.+?)\[/color]#si', '$2', $var);
+        $replacements = array_values($this->tags);
+        $search = array_column($replacements, 'from');
+        $replace = array_column($replacements, 'data');
+        $var = preg_replace($search, $replace, $var);
+
         $var = preg_replace('#\[timestamp\](.+?)\[/timestamp]#si', '$2', $var);
         $var = preg_replace('#\[code=(.+?)\](.+?)\[/code]#si', '$2', $var);
-        $var = preg_replace('!\[bg=(#[0-9a-f]{3}|#[0-9a-f]{6}|[a-z\-]+)](.+?)\[/bg]!is', '$2', $var);
-        $var = preg_replace('#\[spoiler=(.+?)\]#si', '$2', $var);
+
         $replace = [
-            '[small]'    => '',
-            '[/small]'   => '',
-            '[big]'      => '',
-            '[/big]'     => '',
-            '[green]'    => '',
-            '[/green]'   => '',
-            '[red]'      => '',
-            '[/red]'     => '',
-            '[blue]'     => '',
-            '[/blue]'    => '',
-            '[b]'        => '',
-            '[/b]'       => '',
-            '[i]'        => '',
-            '[/i]'       => '',
-            '[u]'        => '',
-            '[/u]'       => '',
-            '[s]'        => '',
-            '[/s]'       => '',
-            '[quote]'    => '',
-            '[/quote]'   => '',
             '[youtube]'  => '',
             '[/youtube]' => '',
             '[php]'      => '',
             '[/php]'     => '',
-            '[c]'        => '',
-            '[/c]'       => '',
-            '[*]'        => '',
-            '[/*]'       => '',
         ];
 
         return strtr($var, $replace);


### PR DESCRIPTION
Изменение решает проблему с очисткой ббкодов, которые записаны в верхнем регистре:

Было  
![image](https://cloud.githubusercontent.com/assets/1321838/25852119/ec48a1fe-34d0-11e7-95e5-6610234f835f.png)

Стало  
![image](https://cloud.githubusercontent.com/assets/1321838/25852088/d66c4e4e-34d0-11e7-9507-918d9b420ad6.png)

А также становится проще добавлять ббкоды — не надо сначала лезть в конфиг, а потом добавлять ещё раз эти теги в функцию очистки, как это [приходилось делать раньше](http://johncms.com/forum/index.php?id=1015769), а то и [вовсе](http://johncms.com/forum/index.php?id=1010994) [забывалось](http://johncms.com/forum/index.php?id=1011050).